### PR TITLE
upgrade to HDF5 1.8.16 and changed download URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ RUN apt-get update
 RUN apt-get -yq install gcc build-essential zlib1g-dev wget
 
 # Build HDF5
-RUN cd ; wget https://www.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.8.15-patch1.tar.gz
-RUN cd ; tar zxf hdf5-1.8.15-patch1.tar.gz
-RUN cd ; mv hdf5-1.8.15-patch1 hdf5-setup
+RUN cd ; wget https://www.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.8.16.tar.gz
+RUN cd ; tar zxf hdf5-1.8.16.tar.gz
+RUN cd ; mv hdf5-1.8.16 hdf5-setup
 RUN cd ; cd hdf5-setup ; ./configure --prefix=/usr/local/
 RUN cd ; cd hdf5-setup ; make && make install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update
 RUN apt-get -yq install gcc build-essential zlib1g-dev wget
 
 # Build HDF5
-RUN cd ; wget https://www.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.8.16.tar.gz
+RUN cd ; wget https://www.hdfgroup.org/ftp/HDF5/prev-releases/hdf5-1.8.16/src/hdf5-1.8.16.tar.gz
 RUN cd ; tar zxf hdf5-1.8.16.tar.gz
 RUN cd ; mv hdf5-1.8.16 hdf5-setup
 RUN cd ; cd hdf5-setup ; ./configure --prefix=/usr/local/


### PR DESCRIPTION
The directory at https://www.hdfgroup.org/ftp/HDF5/current/src/ changed since there is a new release available.
- updated to current version 1.8.16
- changed download URL to www.hdfgroup.org/ftp/HDF5/prev-releases/ so build doesn't break when new version is available

Cheers,
Ben
